### PR TITLE
Add sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The other options available include:
 
 * `host`: The host that Redis is located on. Defaults to 'localhost'.
 * `port`: The port that Redis is running on. Defaults to 6379.
+* `sentinel`: Sentinel configuration (described below)
 * `socket`: Optional Unix socket path
 * `password`: Optional Redis password
 * `db`: The database number to query on the Redis instance. Defaults to 0.
@@ -90,6 +91,29 @@ The other options available include:
   confine_to_keys:
     - "application.*"
     - "apache::.*"
+```
+
+### Sentinel configuration
+
+Include the `sentinel` key in `options` and then use the following config (from [Redis gem v5.0.7](https://www.rubydoc.info/gems/redis/5.0.7#sentinel-support))
+`password` key is optional.
+
+```yaml
+---
+version: 5
+hierarchy:
+  - name: hiera_redis
+    lookup_key: redis_lookup_key
+    options:
+      sentinel:
+        name: mymaster
+        sentinels:
+          - host: '127.0.0.1'
+            port: 26380
+            password: optional_password
+          - host: '127.0.0.1'
+            port: 26381
+            password: optional_password
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ The other options available include:
 Include the `sentinel` key in `options` and then use the following config (from [Redis gem v5.0.7](https://www.rubydoc.info/gems/redis/5.0.7#sentinel-support))
 `password` key is optional.
 
-__IMPORTANT:__ The `sentinels` elements' hash keys need to be __:symbols__
-
 ```yaml
 ---
 version: 5
@@ -110,12 +108,12 @@ hierarchy:
       sentinel:
         name: mymaster
         sentinels:
-          - :host: '127.0.0.1'
-            :port: 26380
-            :password: optional_password
-          - :host: '127.0.0.1'
-            :port: 26381
-            :password: optional_password
+          - host: '127.0.0.1'
+            port: 26380
+            password: optional_password
+          - host: '127.0.0.1'
+            port: 26381
+            password: optional_password
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The other options available include:
 Include the `sentinel` key in `options` and then use the following config (from [Redis gem v5.0.7](https://www.rubydoc.info/gems/redis/5.0.7#sentinel-support))
 `password` key is optional.
 
+__IMPORTANT:__ The `sentinels` elements' hash keys need to be __:symbols__
+
 ```yaml
 ---
 version: 5
@@ -108,12 +110,12 @@ hierarchy:
       sentinel:
         name: mymaster
         sentinels:
-          - host: '127.0.0.1'
-            port: 26380
-            password: optional_password
-          - host: '127.0.0.1'
-            port: 26381
-            password: optional_password
+          - :host: '127.0.0.1'
+            :port: 26380
+            :password: optional_password
+          - :host: '127.0.0.1'
+            :port: 26381
+            :password: optional_password
 ```
 
 ## Limitations

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -41,13 +41,15 @@ Puppet::Functions.create_function(:redis_lookup_key) do
     db        = options['db']        || 0
     scopes    = options['scopes']    || [options['scope']]
     separator = options['separator'] || ':'
-# timeout options, by default 0.5 seconds
+
+    # timeout options, by default 0.5 seconds
+    # added timeouts for redis connections
+    # without it, we will get a lot of not closed TCP connections
     connect_timeout = options['connect_timeout'] || 0.5
     read_timeout = options['read_timeout'] || 0.5
     write_timeout = options['write_timeout'] || 0.5
-# added timeouts for redis connections
-# without it, we will get a lot of not closed TCP connections
-    @redis = begin
+
+    @redis = @redis || begin
       Puppet.debug('hiera-redis: Setting up Redis connection')
       if !sentinel.nil?
         Puppet.debug('hiera-redis: Using Redis sentinel')
@@ -86,8 +88,6 @@ Puppet::Functions.create_function(:redis_lookup_key) do
 
       break unless result.nil?
     end
-    # close redis connection, for fix issue with TCP connects
-    @redis.close()
 
     context.not_found if result.nil?
     # if result contains some hiera or lookup pattern for interpolate it, we need try to make it

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -47,7 +47,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
     write_timeout = options['write_timeout'] || 0.5
 # added timeouts for redis connections
 # without it, we will get a lot of not closed TCP connections
-    @redis = @redis || begin
+    @redis = begin
       Puppet.debug('hiera-redis: Setting up Redis connection')
       if !sentinel.nil?
         Puppet.debug('hiera-redis: Using Redis sentinel')
@@ -87,7 +87,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
       break unless result.nil?
     end
     # close redis connection, for fix issue with TCP connects
-    # redis.close()
+    redis.close()
 
     context.not_found if result.nil?
     # if result contains some hiera or lookup pattern for interpolate it, we need try to make it

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -96,8 +96,13 @@ Puppet::Functions.create_function(:redis_lookup_key) do
       result =  context.interpolate(result)
     end
     # if we can validate json in result, we need to make it and change type of result for context.
-    if valid_json(result) && !([true, false].include?(result))
-      context.cache(key, Hash(JSON.parse(result)))
+    if valid_json(result)
+      sendval = JSON.parse(result)
+      if [true, false].include? sendval
+        context.cache(key, sendval)
+      else
+        context.cache(key, Hash(sendval))
+      end
     else
       context.cache(key, result)
     end

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -50,8 +50,10 @@ Puppet::Functions.create_function(:redis_lookup_key) do
     redis = if !sentinel.nil?
               sentinels = sentinel['sentinels'].map { |val| val.transform_keys(&:to_sym) }
               begin
-                Redis.new(name: sentinel['name'], sentinels: sentinels, role: :replica)
-              rescue RedisClient::ConnectionError => e
+                tred = Redis.new(name: sentinel['name'], sentinels: sentinels, role: :replica)
+                tred.ping
+                tred
+              rescue Redis::BaseError => e
                 if e.message.include? "Couldn't locate a replica"
                   Redis.new(name: sentinel['name'], sentinels: sentinels, role: :master)
                 end

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -87,7 +87,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
       break unless result.nil?
     end
     # close redis connection, for fix issue with TCP connects
-    redis.close()
+    @redis.close()
 
     context.not_found if result.nil?
     # if result contains some hiera or lookup pattern for interpolate it, we need try to make it

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -48,9 +48,9 @@ Puppet::Functions.create_function(:redis_lookup_key) do
 # added timeouts for redis connections
 # without it, we will get a lot of not closed TCP connections
     @redis = @redis || begin
-      debug('hiera-redis: Setting up Redis connection')
+      Puppet.debug('hiera-redis: Setting up Redis connection')
       if !sentinel.nil?
-        debug('hiera-redis: Using Redis sentinel')
+        Puppet.debug('hiera-redis: Using Redis sentinel')
         sentinels = sentinel['sentinels'].map { |val| val.transform_keys(&:to_sym) }
         begin
           tred = Redis.new(name: sentinel['name'], sentinels: sentinels, role: :replica, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
@@ -64,16 +64,16 @@ Puppet::Functions.create_function(:redis_lookup_key) do
           end
         end
       elsif !socket.nil? && !password.nil?
-        debug('hiera-redis: Using socket with password')
+        Puppet.debug('hiera-redis: Using socket with password')
         Redis.new(path: socket, password: password, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
       elsif !socket.nil? && password.nil?
-        debug('hiera-redis: Using socket without password')
+        Puppet.debug('hiera-redis: Using socket without password')
         Redis.new(path: socket, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
       elsif socket.nil? && !password.nil?
-        debug('hiera-redis: Using TCP with password')
+        Puppet.debug('hiera-redis: Using TCP with password')
         Redis.new(password: password, host: host, port: port, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
       else
-        debug('hiera-redis: Using TCP without password')
+        Puppet.debug('hiera-redis: Using TCP without password')
         Redis.new(host: host, port: port, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
       end
     end
@@ -81,7 +81,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
 
     scopes.each do |scope|
       redis_key = scope.nil? ? key : [scope, key].join(separator)
-      debug("hiera-redis: Looking up '#{redis_key}'")
+      Puppet.debug("hiera-redis: Looking up '#{redis_key}'")
       result = redis_get(@redis, redis_key)
 
       break unless result.nil?

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -47,7 +47,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
     write_timeout = options['write_timeout'] || 0.5
 # added timeouts for redis connections
 # without it, we will get a lot of not closed TCP connections
-    @redis = @redis || {
+    @redis = @redis || begin
       debug('hiera-redis: Setting up Redis connection')
       if !sentinel.nil?
         debug('hiera-redis: Using Redis sentinel')
@@ -76,7 +76,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
         debug('hiera-redis: Using TCP without password')
         Redis.new(host: host, port: port, db: db, connect_timeout: connect_timeout, read_timeout: read_timeout, write_timeout: write_timeout)
       end
-    }
+    end
     result = nil
 
     scopes.each do |scope|

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -96,18 +96,18 @@ Puppet::Functions.create_function(:redis_lookup_key) do
       result =  context.interpolate(result)
     end
     # if we can validate json in result, we need to make it and change type of result for context.
-    if valid_json(result)
-       context.cache(key, Hash(JSON.parse(result)))
+    if valid_json(result) && !([true, false].include?(result))
+      context.cache(key, Hash(JSON.parse(result)))
     else
-       context.cache(key, result)
+      context.cache(key, result)
     end
   end
 # we just trt validate it, if we can without error - return true, if not - false.
   def valid_json(json)
-      JSON.parse(json)
-      return true
+    JSON.parse(json)
+    return true
   rescue TypeError, JSON::ParserError => e
-     return false
+    return false
   end
 
   def redis_get(redis, key)

--- a/lib/puppet/functions/redis_lookup_key.rb
+++ b/lib/puppet/functions/redis_lookup_key.rb
@@ -97,12 +97,7 @@ Puppet::Functions.create_function(:redis_lookup_key) do
     end
     # if we can validate json in result, we need to make it and change type of result for context.
     if valid_json(result)
-      sendval = JSON.parse(result)
-      if [true, false].include? sendval
-        context.cache(key, sendval)
-      else
-        context.cache(key, Hash(sendval))
-      end
+      context.cache(key, JSON.parse(result))
     else
       context.cache(key, result)
     end


### PR DESCRIPTION
This adds the ability to configure a list of sentinels in the backend's `options`.

It also removes the `redis.close` call as it is configured to re-use an existing connection during compilation rather than need to establish hundreds of new connections that the `redis.close` call was protecting against.

This is intended to be a squashed merge, but if it is desired, that can be pre-squashed on this branch.